### PR TITLE
feat: start surfpool

### DIFF
--- a/rustenroll/.surfpool/logs/simnet_2025-09-04--14-53-48.log
+++ b/rustenroll/.surfpool/logs/simnet_2025-09-04--14-53-48.log
@@ -1,0 +1,10 @@
+[2025-09-04--14-53-48 INFO actix_server::builder] starting 5 workers
+[2025-09-04--14-53-48 INFO actix_server::server] Tokio runtime found; starting in existing Tokio runtime
+[2025-09-04--14-53-48 INFO actix_server::server] starting service: "actix-web-service-127.0.0.1:18488", workers: 5, listening on: 127.0.0.1:18488
+[2025-09-04--14-53-48 INFO parity_ws] Listening for new connections on 127.0.0.1:8900.
+[2025-09-04--14-53-51 INFO actix_server::worker] shutting down idle worker
+[2025-09-04--14-53-51 INFO actix_server::worker] shutting down idle worker
+[2025-09-04--14-53-51 INFO actix_server::worker] shutting down idle worker
+[2025-09-04--14-53-51 INFO actix_server::worker] shutting down idle worker
+[2025-09-04--14-53-51 INFO actix_server::worker] shutting down idle worker
+[2025-09-04--14-53-51 INFO actix_server::accept] accept thread stopped

--- a/rustenroll/runbooks/README.md
+++ b/rustenroll/runbooks/README.md
@@ -1,0 +1,85 @@
+# rustenroll Runbooks
+
+[![Surfpool](https://img.shields.io/badge/Operated%20with-Surfpool-gree?labelColor=gray)](https://surfpool.run)
+
+## Available Runbooks
+
+### deployment
+Deploy programs
+
+## Getting Started
+
+This repository is using [Surfpool](https://surfpool.run) as a part of its development workflow.
+
+Surfpool provides three major upgrades to the Solana development experience:
+- **Surfnet**: A local validator that runs on your machine, allowing you fork mainnet on the fly so that you always use the latest chain data when testing your programs.
+- **Runbooks**: Bringing the devops best practice of `infrastructure as code` to Solana, Runbooks allow you to have secure, reproducible, and composable scripts for managing on-chain operations & deployments.
+- **Surfpool Studio**: An all-local Web UI that gives new levels of introspection into your transactions.
+
+### Installation
+
+Install pre-built binaries:
+
+```console
+# macOS (Homebrew)
+brew install txtx/taps/surfpool
+
+# Updating surfpool for Homebrew users
+brew tap txtx/taps
+brew reinstall surfpool
+
+# Linux (Snap Store)
+snap install surfpool
+```
+
+Install from source:
+
+```console
+# Clone repo
+git clone https://github.com/txtx/surfpool.git
+
+# Set repo as current directory
+cd surfpool
+
+# Build
+cargo surfpool-install
+```
+
+### Start a Surfnet
+
+```console
+$ surfpool start
+```
+
+## Resources
+
+Access tutorials and documentation at [docs.surfpool.run](https://docs.surfpool.run) to understand Surfnets and the Runbook syntax, and to discover the powerful features of surfpool.
+
+Additionally, the [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=txtx.txtx) will make writing runbooks easier.
+
+Our [Surfpool 101 Series](https://www.youtube.com/playlist?list=PL0FMgRjJMRzO1FdunpMS-aUS4GNkgyr3T) is also a great place to start learning about Surfpool and its features:
+<a href="https://www.youtube.com/playlist?list=PL0FMgRjJMRzO1FdunpMS-aUS4GNkgyr3T">
+  <picture>
+    <source srcset="https://raw.githubusercontent.com/txtx/surfpool/main/doc/assets/youtube.png">
+    <img alt="Surfpool 101 series" style="max-width: 100%;">
+  </picture>
+</a>
+
+## Quickstart
+
+### List runbooks available in this repository
+```console
+$ surfpool ls
+Name                                    Description
+deployment                              Deploy programs
+```
+
+### Start a Surfnet, automatically executing the `deployment` runbook on program recompile:
+```console
+$ surfpool start --watch
+```
+
+### Execute an existing runbook
+```console
+$ surfpool run deployment
+```

--- a/rustenroll/runbooks/deployment/main.tx
+++ b/rustenroll/runbooks/deployment/main.tx
@@ -1,0 +1,19 @@
+################################################################
+# Manage rustenroll deployment through Crypto Infrastructure as Code
+################################################################
+
+addon "svm" {
+    rpc_api_url = input.rpc_api_url
+    network_id = input.network_id
+}
+
+action "deploy_rustenroll" "svm::deploy_program" {
+    description = "Deploy rustenroll program"
+    program = svm::get_program_from_native_project("rustenroll") 
+    authority = signer.authority
+    payer = signer.payer
+    // Optional: if you want to deploy the program via a cheatcode when targeting a Surfnet, set `instant_surfnet_deployment = true`
+    // Deploying via a cheatcode will write the program data directly to the program account, rather than sending transactions.
+    // This will make deployments instantaneous, but is deviating from how the deployments will take place on devnet/mainnet.
+    // instant_surfnet_deployment = true
+}

--- a/rustenroll/runbooks/deployment/signers.devnet.tx
+++ b/rustenroll/runbooks/deployment/signers.devnet.tx
@@ -1,0 +1,12 @@
+
+signer "payer" "svm::web_wallet" {
+    description = "Pays fees for program deployments and operations"
+    // Optional: the public key of the signer can be enforced at runtime by setting an expected value
+    // expected_address = "zbBjhHwuqyKMmz8ber5oUtJJ3ZV4B6ePmANfGyKzVGV"
+}
+
+signer "authority" "svm::web_wallet" {
+    description = "Can upgrade programs and manage critical ops"
+    // expected_address = input.expected_payer_address
+    // See documentation for other options (squads, etc): https://docs.surfpool.run/iac/svm/signers
+}

--- a/rustenroll/runbooks/deployment/signers.localnet.tx
+++ b/rustenroll/runbooks/deployment/signers.localnet.tx
@@ -1,0 +1,11 @@
+
+signer "payer" "svm::secret_key" {
+    description = "Pays fees for program deployments and operations"
+    keypair_json = "~/.config/solana/id.json"
+    // See documentation for other options (mnemonic, etc): https://docs.surfpool.run/iac/svm/signers
+}
+    
+signer "authority" "svm::secret_key" {
+    description = "Can upgrade programs and manage critical ops"
+    keypair_json = "~/.config/solana/id.json"
+}

--- a/rustenroll/runbooks/deployment/signers.mainnet.tx
+++ b/rustenroll/runbooks/deployment/signers.mainnet.tx
@@ -1,0 +1,14 @@
+
+// For mainnet deployment, use web wallets, hardware wallets or multisig to improve key security.
+
+signer "payer" "svm::web_wallet" {
+    description = "Pays fees for program deployments and operations"
+    // Optional: the public key of the signer can be enforced at runtime by setting an expected value
+    // expected_address = "zbBjhHwuqyKMmz8ber5oUtJJ3ZV4B6ePmANfGyKzVGV"
+}
+
+signer "authority" "svm::web_wallet" {
+    description = "Can upgrade programs and manage critical ops"
+    // expected_address = input.expected_payer_address
+    // See documentation for other options (squads, etc): https://docs.surfpool.run/iac/svm/signers
+}

--- a/rustenroll/txtx.yml
+++ b/rustenroll/txtx.yml
@@ -1,0 +1,17 @@
+---
+name: rustenroll
+id: rustenroll
+runbooks:
+  - name: deployment
+    description: Deploy programs
+    location: runbooks/deployment
+environments:
+  localnet:
+      network_id: localnet
+      rpc_api_url: http://127.0.0.1:8899
+  devnet:
+      network_id: devnet
+      rpc_api_url: https://api.devnet.solana.com
+      payer_keypair_json: ~/.config/solana/id.json
+      authority_keypair_json: ~/.config/solana/id.json
+


### PR DESCRIPTION
Github Growth PR Summary
This PR adds a minimal txtx runbook so the repo is compatible with Surfpool and helps support syntax highlighting for the [Txtx Language](https://www.youtube.com/watch?v=UeRdvhnKv8c). 

Why Txtx Runbooks
Txtx Runbooks make deploying your program to Surfpool simple and fast, while upgrading the security of your devnet + mainnet deployments.

Usage
Once you have [installed Surfpool](https://github.com/txtx/surfpool?tab=readme-ov-file#installation), simply run:
```sh
surfpool start
```
in the home directory of your project and you will have a local validator running with your program deployed to it! 🚀

Why Are We Opening This PR?
We’re working to get official Txtx language highlighting on GitHub. To qualify, GitHub requires at least 100 repositories actively using the language.

* Turbin3 repos are already compatible with surfpool and runbooks
* Adding this runbook ensures compatibility and helps the broader ecosystem
* Once we reach the threshold, all projects will benefit from proper syntax highlighting on GitHub

What’s included

* Added a the basic surfpool + runbooks start
* Added documentation instructions

Impact

* No breaking changes
* No effect on existing code execution
* Opt-in for future infrastructure-as-code workflows with Txtx

Next Steps
If merged, this repo will count toward the 100-project requirement.
Thanks for supporting the community push for better tooling 🚀
